### PR TITLE
[EDB-175] Fix validators for StringNumberType and AccountOrContractIdType

### DIFF
--- a/src/modules/api/types/account.or.contract.id.type.ts
+++ b/src/modules/api/types/account.or.contract.id.type.ts
@@ -2,7 +2,7 @@ import { validators, constants } from 'echojs-lib';
 import { GraphQLScalarType, Kind, GraphQLError } from 'graphql';
 
 function check(value: string) {
-	if (!validators.isAccountId(value) || !validators.isContractId(value)) throw new GraphQLError('');
+	if (!validators.isAccountId(value) && !validators.isContractId(value)) throw new GraphQLError('');
 	return value;
 }
 

--- a/src/modules/api/types/string.number.type.ts
+++ b/src/modules/api/types/string.number.type.ts
@@ -5,7 +5,7 @@ export default new GraphQLScalarType({
 	name: 'StringifiedNumber',
 	description: 'Number that converted to string',
 	parseValue(value: string | number) {
-		if (typeof value !== 'string' || typeof value !== 'number') throw new GraphQLError('');
+		if (typeof value !== 'string' && typeof value !== 'number') throw new GraphQLError('');
 		return new BN(value).toString();
 	},
 	serialize(value: string) {


### PR DESCRIPTION
Fix conditional operators for StringNumberType and AccountOrContractIdType from " || " to " && ". Cause in both sides are negate conditions.