### PR TITLE
[EDB-174] Parse contract to account transfers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "echodb",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"repository": {
 		"type": "git",
 		"url": "git@github.com:echoprotocol/echodb.git"

--- a/src/constants/model.constants.ts
+++ b/src/constants/model.constants.ts
@@ -1,16 +1,16 @@
 // TODO: check tslint here
 // TODO: rename to db.constants
 
-// FIXME: use enum
-export const NAME = {
-	INFO: 'info',
-	BLOCK: 'block',
-	TANSFER: 'transfer',
-	TRANSACTION: 'transaction',
-	OPERATION: 'operation',
-	ACCOUNT: 'account',
-	ASSET: 'asset',
-	CONTRACT: 'contract',
-	CONTRACT_BALANCE: 'contract_balance',
-	BALANCE: 'balance',
-};
+export enum NAME {
+	INFO = 'info',
+	BLOCK = 'block',
+	TANSFER = 'transfer',
+	TRANSACTION = 'transaction',
+	OPERATION = 'operation',
+	ACCOUNT = 'account',
+	ASSET = 'asset',
+	CONTRACT = 'contract',
+	CONTRACT_BALANCE = 'contract_balance',
+	BALANCE = 'balance',
+	CONTRACT_CALLER = 'contract_caller',
+}

--- a/src/interfaces/IContract.ts
+++ b/src/interfaces/IContract.ts
@@ -16,6 +16,5 @@ export interface IContract {
 	type: CONTRACT.TYPE;
 	token_info?: ITokenInfo;
 	_block: MongoId;
-	_calling_accounts?: MongoId[];
 	problem: boolean;
 }

--- a/src/interfaces/IContractCaller.ts
+++ b/src/interfaces/IContractCaller.ts
@@ -1,0 +1,10 @@
+import { NAME as ModelName } from '../constants/model.constants';
+import { MongoId } from '../types/mongoose';
+
+export const callerModelPath = 'callerModel';
+
+export default interface IContractCaller {
+	contract: MongoId;
+	caller: MongoId;
+	[callerModelPath]: ModelName.CONTRACT | ModelName.ACCOUNT;
+}

--- a/src/models/contract.caller.model.ts
+++ b/src/models/contract.caller.model.ts
@@ -1,0 +1,12 @@
+import { NAME as ModelName } from '../constants/model.constants';
+import abstractModel from './abstract.model';
+import IContractCaller, { callerModelPath } from '../interfaces/IContractCaller';
+import { Schema } from 'mongoose';
+
+const contractCallerModel = abstractModel<IContractCaller>(ModelName.CONTRACT_CALLER, {
+	contract: { type: Schema.Types.ObjectId, required: true, ref: ModelName.CONTRACT, index: true },
+	[callerModelPath]: { type: String, required: true, enum: [ModelName.CONTRACT, ModelName.ACCOUNT] },
+	caller: { type: Schema.Types.ObjectId, required: true, refPath: callerModelPath, index: true },
+});
+
+export default contractCallerModel;

--- a/src/models/contract.model.ts
+++ b/src/models/contract.model.ts
@@ -19,7 +19,6 @@ export default AbstractModel<IContract>(MODEL.NAME.CONTRACT, {
 	type: { $type: String, enum: Object.values(CONTRACT.TYPE) },
 	token_info: erc20infoSchema,
 	_block: { ref: MODEL.NAME.BLOCK, $type: Schema.Types.ObjectId },
-	_calling_accounts: [{ ref: MODEL.NAME.ACCOUNT, $type: Schema.Types.ObjectId }],
 	problem: { $type: Boolean, default: false },
 }, {
 	typeKey: '$type',

--- a/src/modules/api/resolvers/contract.resolver.ts
+++ b/src/modules/api/resolvers/contract.resolver.ts
@@ -66,8 +66,8 @@ export default class ContractResolver extends AbstractResolver {
 	}
 
 	@FieldResolver()
-	calling_accounts(@Root('_calling_accounts') ids: Contract['_calling_accounts']) {
-		return this.resolveArrayMongoField(ids, this.accountRepository);
+	callers(@Root() contract: Contract['_id']) {
+		return this.contractService.getCallers(contract);
 	}
 
 	@FieldResolver()

--- a/src/modules/api/types/contract.type.ts
+++ b/src/modules/api/types/contract.type.ts
@@ -4,12 +4,24 @@ import Block from './block.type';
 import Token from './token.type';
 import * as CONTRACT from '../../../constants/contract.constants';
 import { IAccount } from '../../../interfaces/IAccount';
-import { TDoc } from '../../../types/mongoose';
+import { TDoc, MongoId } from '../../../types/mongoose';
 import { ObjectType, Field } from 'type-graphql';
 import { IBlock } from '../../../interfaces/IBlock';
+import { IContract } from 'interfaces/IContract';
+
+@ObjectType()
+export class ContractCallers {
+	@Field(() => [Contract])
+	contracts: TDoc<IContract>[];
+
+	@Field(() => [Account])
+	accounts: TDoc<IAccount>[];
+}
 
 @ObjectType()
 export default class Contract {
+	_id: MongoId<IContract>;
+
 	@Field(() => ContractId)
 	id: string;
 
@@ -33,7 +45,6 @@ export default class Contract {
 	@Field(() => Block, { nullable: true })
 	block: Block;
 
-	_calling_accounts: TDoc<IAccount>[];
-	@Field(() => [Account], { nullable: true })
-	calling_accounts: Account[];
+	@Field(() => ContractCallers, { nullable: true })
+	callers: ContractCallers;
 }

--- a/src/modules/parser/operations/contract.call.operation.ts
+++ b/src/modules/parser/operations/contract.call.operation.ts
@@ -41,7 +41,7 @@ export default class ContractCallOperation extends AbstractOperation<OP_ID> {
 			const dAccount = await this.accountRepository.findById(body.registrar);
 			const [dAsset] = await Promise.all([
 				this.assetRepository.findById(body.value.asset_id),
-				this.contractService.updateContractCallingAccounts(dContract, dAccount._id),
+				this.contractService.updateContractCaller(dContract, dAccount.id),
 			]);
 			if (amount) {
 				await this.contractBalanceRepository.updateOrCreateByOwnerAndAsset(
@@ -58,7 +58,7 @@ export default class ContractCallOperation extends AbstractOperation<OP_ID> {
 				);
 			}
 		} else {
-			logger.warn('contract not found, can not parse call');
+			logger.warn(`contract ${body.callee} not found, can not parse call`);
 		}
 		return this.validateRelation({
 			from: [body.registrar],
@@ -74,6 +74,7 @@ export default class ContractCallOperation extends AbstractOperation<OP_ID> {
 		relations: IOperationRelation,
 	) {
 		const dContract = await this.contractRepository.findById(body.callee);
+		if (!dContract) return relations;
 		if (dContract.type !== CONTRACT.TYPE.ERC20) {
 			return relations;
 		}

--- a/src/modules/parser/operations/operation.manager.ts
+++ b/src/modules/parser/operations/operation.manager.ts
@@ -214,7 +214,12 @@ export default class OperationManager {
 		if (body.fee) await this.balanceService.takeFee(preInternalRelation.from[0], body.fee);
 		if (body.virtual_operations) {
 			for (const virtualOperation of body.virtual_operations) {
-				await this.parseKnownOperation(virtualOperation[0], virtualOperation[1], result, dBlock);
+				const [vopId, vopProps] = virtualOperation;
+				if (!this.map[vopId as ECHO.OPERATION_ID]) {
+					logger.warn(`Internal operation ${vopId} is not supported`);
+					continue;
+				}
+				await this.parseKnownOperation(vopId, vopProps, result, dBlock);
 			}
 		}
 		const postInternalRelation = await this.map[id].postInternalParse(body, result, dBlock, preInternalRelation);

--- a/src/repositories/contract.caller.repository.ts
+++ b/src/repositories/contract.caller.repository.ts
@@ -1,0 +1,8 @@
+import AbstractRepository from './abstract.repository';
+import IContractCaller from '../interfaces/IContractCaller';
+import RavenHelper from '../helpers/raven.helper';
+import contractCallerModel from '../models/contract.caller.model';
+
+export default class ContractCallerRepository extends AbstractRepository<IContractCaller> {
+	constructor(ravenHelper: RavenHelper) { super(ravenHelper, contractCallerModel); }
+}


### PR DESCRIPTION
* GraphQL:
  * Changed field `_calling_accounts` to `callers` with struct:
```ts
contracts: Contract[]
account: Account[]
```
* DB:
  * Removed field `_calling_accounts` from `contracts` collection
  * Added collection `contract_callers` with struct:
```ts
contract: Contract["_id"]
callerModel: "account" | "contract"
caller: Contract["_id"] if callerModel == "contract" else Account["_id"]
```
* Parser:
  * Added contract to account internal transfers
* Fixed:
  * Error on trying to parsing internal unknown operation
  * Relation building on parsing `contract_internal_call_operation`